### PR TITLE
chore: Add serialize-javascript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "bolt-auction",
   "version": "0.1.0",
   "private": true,
+  "main": "index.js",
+  "repository": "https://github.com/bolt-auction/bolt-auction-frontend.git",
+  "author": "bolt-auction",
+  "contributors": [
+    "Sub2n <95su1208@gmail.com>",
+    "JiSop <jisop.shin@gmail.com>"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
@@ -19,11 +33,17 @@
     "redux-logger": "^3.0.6",
     "redux-saga": "^1.1.3"
   },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+  "devDependencies": {
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "normalize.css": "^8.0.1",
+    "prettier": "1.19.1",
+    "qs": "^6.9.1",
+    "react-icons": "^3.9.0",
+    "styled-components": "^5.0.0"
+  },
+  "resolutions": {
+    "serialize-javascript": "^2.1.2"
   },
   "browserslist": {
     "production": [
@@ -36,18 +56,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "main": "index.js",
-  "repository": "https://github.com/Sub2n/bolt-auction.git",
-  "author": "Sub2n <95su1208@gmail.com>",
-  "license": "MIT",
-  "devDependencies": {
-    "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "normalize.css": "^8.0.1",
-    "prettier": "1.19.1",
-    "qs": "^6.9.1",
-    "react-icons": "^3.9.0",
-    "styled-components": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9471,15 +9471,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
-  integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
+serialize-javascript@^1.7.0, serialize-javascript@^2.1.0, serialize-javascript@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serve-index@^1.9.1:
   version "1.9.1"


### PR DESCRIPTION
github repo에서 security alert을 해결하기 위해 serialize-javascript dependency를 추가 했습니다.

하는 김에 보기 편하게 순서 변경하고 `"repository"`, `"author"` 수정하고 `"contributors"`를 추가했습니다!

아래 링크 참고해서 수정했어요🧐
[[Security] Issue with serialize-javascript #8100](https://github.com/facebook/create-react-app/issues/8100#issuecomment-565728513)
[[Manager] Update serialize-javascript to fix GitHub's security warning #3493](https://github.com/oharastream/ohara/issues/3493)